### PR TITLE
CSW-937/CS-9131: synch changes from CSW-908 to listapps_CS-9131.py

### DIFF
--- a/listapps_CS-9131.py
+++ b/listapps_CS-9131.py
@@ -157,7 +157,7 @@ APPS = {
     'search': 'Public Portal',
     'imageadjuster': 'Image Adjuster',
     'merritt_archive': 'Merritt Archiving',
-    'osteology': 'Osteology Portal',
+    # 'osteology': 'Osteology Portal',
     'publicsearch': '"legacy" Public Portal',
     'ireports': 'iReports',
     'uploadmedia': 'Bulk Media Upload',


### PR DESCRIPTION
copied listapps_CS-9131.py from PROD which did not have changes from CSW-908 to exclude/retire osteology portal. See PR # 14.